### PR TITLE
feat: support different package.json location

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,20 @@ export default {
   ],
 }
 ```
+
+## Options
+### packageJsonPath
+If your `package.json` is not in the current working directory you can specify the path to the file
+```javascript
+// Add to plugins array in rollup.config.js
+import peerDepsExternal from 'rollup-plugin-peer-deps-external';
+
+export default {
+  plugins: [
+    // Preferably set as first plugin.
+    peerDepsExternal({
+      packageJsonPath: 'my/folder/package.json'
+    }),
+  ],
+}
+```

--- a/src/get-peer-deps.js
+++ b/src/get-peer-deps.js
@@ -1,7 +1,8 @@
-export default function getPeerDeps() {
+const { resolve } = require('path');
+
+export default function getPeerDeps(path = resolve(process.cwd(), 'package.json')) {
   try {
-    const { resolve } = require('path');
-    const pkg = require(resolve(process.cwd(), 'package.json'));
+    const pkg = require(path);
     return Object.keys(pkg.peerDependencies);
   } catch (err) {
     return [];

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import externalToFn from './external-to-fn';
 import getModulesMatcher from './get-modules-matcher';
 import getPeerDeps from './get-peer-deps';
 
-export default function PeerDepsExternalPlugin() {
+export default function PeerDepsExternalPlugin({packageJsonPath} = {}) {
   return {
     name: 'peer-deps-external',
     options: opts => {
@@ -11,7 +11,7 @@ export default function PeerDepsExternalPlugin() {
         // Retain existing `external` config
         externalToFn(opts.external),
         // Add `peerDependencies` to `external` config
-        getModulesMatcher(getPeerDeps())
+        getModulesMatcher(getPeerDeps(packageJsonPath))
       );
 
       return opts;


### PR DESCRIPTION
- when the `package.json` is not in the current working directory we might want to tell the plugin where to require from