### PR TITLE
any version of rollup can be used by consumers

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "module": "./dist/rollup-plugin-peer-deps-external.module.js",
   "license": "MIT",
   "peerDependencies": {
-    "rollup": "^0.x"
+    "rollup": "*"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",


### PR DESCRIPTION
fix https://github.com/Updater/rollup-plugin-peer-deps-external/issues/10

changed rollup peerDependencies to allow any version to be used by consumers.
https://github.com/npm/node-semver#x-ranges-12x-1x-12-

not likely that external behavior will change so just allow any version to work.