### PR TITLE
fix: add link to npmjs and release rollup peerep

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "rollup-plugin-peer-deps-external",
   "version": "0.0.0-development",
   "description": "Rollup plugin to automatically add a library's peerDependencies to its bundle's external config.",
+  "repository": "Updater/rollup-plugin-peer-deps-external",  
   "keywords": [
     "rollup",
     "plugin",


### PR DESCRIPTION
https://github.com/Updater/rollup-plugin-peer-deps-external/pull/11

in this PR we make a safe change to the package.json. Using this + fix in the commit message to release this and the previous (accidentally) merged pull request missing the Semantic Release keyword to trigger the release. 